### PR TITLE
feat: add tooltip aggregation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,26 @@ const gradient: GradientStop[] = [
 const heatmap = createHeatmap({ container, gradient });
 ```
 
+### Aggregation Modes
+
+Control how multiple points in the same grid cell are combined. This affects both tooltip values and legend range:
+
+```typescript
+import { createHeatmap } from "@drdreo/heatmap";
+
+const heatmap = createHeatmap({
+    container,
+    aggregationMode: "max" // 'max' | 'sum' | 'mean' | 'count'
+});
+```
+
+| Mode    | Description                     | Use Case                        |
+| ------- | ------------------------------- | ------------------------------- |
+| `max`   | Use the maximum value (default) | Peak intensity visualization    |
+| `sum`   | Add all values together         | Click tracking, cumulative data |
+| `mean`  | Calculate the average           | Normalized/density data         |
+| `count` | Count the number of points      | Pure density visualization      |
+
 ## Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ const heatmap = createHeatmap({ container, gradient });
 
 ### Aggregation Modes
 
-Control how multiple points in the same grid cell are combined. This affects both tooltip values and legend range:
+Control how multiple points in the same grid cell are combined for tooltip and legend values:
 
 ```typescript
 import { createHeatmap } from "@drdreo/heatmap";
@@ -173,6 +173,8 @@ const heatmap = createHeatmap({
 | `sum`   | Add all values together         | Click tracking, cumulative data |
 | `mean`  | Calculate the average           | Normalized/density data         |
 | `count` | Count the number of points      | Pure density visualization      |
+
+> **Note**: Aggregation affects tooltip and legend values. Visual rendering uses radial gradient blending through canvas compositing. For additive visual effects, combine with `blendMode: 'lighter'`.
 
 ## Contributing
 

--- a/docs/src/components/sections/ApiReference.vue
+++ b/docs/src/components/sections/ApiReference.vue
@@ -85,7 +85,7 @@ const heatmapConfigOptions: ConfigOption[] = [
         type: "'max' | 'sum' | 'mean' | 'count'",
         default: "'max'",
         description:
-            "How to combine multiple points in the same grid cell. Affects both tooltip values and legend range."
+            "How to aggregate values for tooltip/legend. Visual rendering uses canvas blending separately."
     }
 ];
 

--- a/docs/src/components/sections/ApiReference.vue
+++ b/docs/src/components/sections/ApiReference.vue
@@ -79,6 +79,13 @@ const heatmapConfigOptions: ConfigOption[] = [
         default: "1",
         description:
             "Exponent for intensity curve. Values < 1 boost low values, > 1 emphasize high values."
+    },
+    {
+        name: "aggregationMode",
+        type: "'max' | 'sum' | 'mean' | 'count'",
+        default: "'max'",
+        description:
+            "How to combine multiple points in the same grid cell. Affects both tooltip values and legend range."
     }
 ];
 

--- a/docs/src/components/sections/CustomizationDemo.vue
+++ b/docs/src/components/sections/CustomizationDemo.vue
@@ -6,6 +6,7 @@ import {
     type GradientPresetName,
     type Heatmap,
     type HeatmapPoint,
+    type AggregationMode,
     withLegend,
     withTooltip
 } from "@drdreo/heatmap";
@@ -56,6 +57,7 @@ let customGridSize = ref(20);
 let currentGradient = ref<GradientPresetName>("cool");
 let currentBlendMode = ref<GlobalCompositeOperation>("source-over");
 let currentIntensityExponent = ref(1);
+let currentAggregationMode = ref<AggregationMode>("max");
 
 // Toggle between random and custom data mode
 let useCustomData = ref(false);
@@ -88,6 +90,13 @@ const blendModeOptions = [
     { value: "lighter", label: "Lighter (Additive - overlaps glow brighter)" }
 ];
 
+const aggregationModeOptions = [
+    { value: "max", label: "Max (Peak value at each location)" },
+    { value: "sum", label: "Sum (Add values together)" },
+    { value: "mean", label: "Mean (Average value)" },
+    { value: "count", label: "Count (Number of points)" }
+];
+
 function generateRandomPoints(
     count: number,
     width: number,
@@ -114,7 +123,8 @@ function createCustomHeatmap() {
             gridSize: customGridSize.value,
             gradient: GRADIENT_PRESETS[currentGradient.value],
             blendMode: currentBlendMode.value,
-            intensityExponent: currentIntensityExponent.value
+            intensityExponent: currentIntensityExponent.value,
+            aggregationMode: currentAggregationMode.value
         },
         withTooltip(),
         withLegend({
@@ -344,6 +354,26 @@ onUnmounted(() => {
                         v-model.number="currentIntensityExponent"
                         @input="handleSliderChange"
                     />
+                </div>
+                <div class="control-group">
+                    <label>
+                        Aggregation Mode:
+                        <small style="opacity: 0.7"
+                            >(how overlapping points combine)</small
+                        >
+                    </label>
+                    <select
+                        v-model="currentAggregationMode"
+                        @change="handleSliderChange"
+                    >
+                        <option
+                            v-for="opt in aggregationModeOptions"
+                            :key="opt.value"
+                            :value="opt.value"
+                        >
+                            {{ opt.label }}
+                        </option>
+                    </select>
                 </div>
                 <div class="control-group data-mode-control">
                     <label class="toggle-label">

--- a/docs/src/components/sections/CustomizationDemo.vue
+++ b/docs/src/components/sections/CustomizationDemo.vue
@@ -359,7 +359,7 @@ onUnmounted(() => {
                     <label>
                         Aggregation Mode:
                         <small style="opacity: 0.7"
-                            >(how overlapping points combine)</small
+                            >(tooltip/legend only)</small
                         >
                     </label>
                     <select

--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,6 @@
 {
     "$schema": "./node_modules/nx/schemas/nx-schema.json",
+    "defaultBase": "master",
     "targetDefaults": {
         "build": {
             "dependsOn": ["^build"],

--- a/packages/heatmap/README.md
+++ b/packages/heatmap/README.md
@@ -156,7 +156,7 @@ const heatmap = createHeatmap({ container, gradient });
 
 ### Aggregation Modes
 
-Control how multiple points in the same grid cell are combined. This affects both tooltip values and legend range:
+Control how multiple points in the same grid cell are combined for tooltip and legend values:
 
 ```typescript
 import { createHeatmap } from "@drdreo/heatmap";
@@ -173,6 +173,8 @@ const heatmap = createHeatmap({
 | `sum`   | Add all values together         | Click tracking, cumulative data |
 | `mean`  | Calculate the average           | Normalized/density data         |
 | `count` | Count the number of points      | Pure density visualization      |
+
+> **Note**: Aggregation affects tooltip and legend values. Visual rendering uses radial gradient blending through canvas compositing. For additive visual effects, combine with `blendMode: 'lighter'`.
 
 ## API
 

--- a/packages/heatmap/README.md
+++ b/packages/heatmap/README.md
@@ -154,6 +154,26 @@ const gradient: GradientStop[] = [
 const heatmap = createHeatmap({ container, gradient });
 ```
 
+### Aggregation Modes
+
+Control how multiple points in the same grid cell are combined. This affects both tooltip values and legend range:
+
+```typescript
+import { createHeatmap } from "@drdreo/heatmap";
+
+const heatmap = createHeatmap({
+    container,
+    aggregationMode: "max" // 'max' | 'sum' | 'mean' | 'count'
+});
+```
+
+| Mode    | Description                     | Use Case                        |
+| ------- | ------------------------------- | ------------------------------- |
+| `max`   | Use the maximum value (default) | Peak intensity visualization    |
+| `sum`   | Add all values together         | Click tracking, cumulative data |
+| `mean`  | Calculate the average           | Normalized/density data         |
+| `count` | Count the number of points      | Pure density visualization      |
+
 ## API
 
 ### HeatmapConfig
@@ -172,6 +192,7 @@ const heatmap = createHeatmap({ container, gradient });
 | `gridSize`           | `number`                   | `10`             | Grid cell size for value lookups           |
 | `blendMode`          | `GlobalCompositeOperation` | `source-over`    | Canvas blend mode (`lighter` for additive) |
 | `intensityExponent`  | `number`                   | `1`              | Intensity curve exponent                   |
+| `aggregationMode`    | `AggregationMode`          | `'max'`          | How to combine overlapping points          |
 | `valueMin`           | `number`                   | -                | Fixed minimum value for consistent scales  |
 | `valueMax`           | `number`                   | -                | Fixed maximum value for consistent scales  |
 | `data`               | `HeatmapData`              | -                | Initial data                               |

--- a/packages/heatmap/src/core/heatmap.spec.ts
+++ b/packages/heatmap/src/core/heatmap.spec.ts
@@ -175,7 +175,8 @@ describe("createHeatmap (composable API)", () => {
                 { x: 4, y: 4, value: 20 }
             ]);
 
-            expect(heatmap.getValueAt(3, 3)).toBe(50);
+            // Default aggregation is 'max', so returns the max value in the cell
+            expect(heatmap.getValueAt(3, 3)).toBe(30);
         });
 
         it("should export as data URL", () => {

--- a/packages/heatmap/src/core/index.ts
+++ b/packages/heatmap/src/core/index.ts
@@ -7,6 +7,7 @@
 export { validateConfig, type ResolvedConfig } from "./validation";
 export { generatePalette, parseColor, createGradientCanvas } from "./gradient";
 export type {
+    AggregationMode,
     Heatmap,
     HeatmapConfig,
     HeatmapData,

--- a/packages/heatmap/src/core/types.ts
+++ b/packages/heatmap/src/core/types.ts
@@ -234,13 +234,18 @@ export interface HeatmapConfig {
     /**
      * Aggregation mode for combining multiple points in the same grid cell (default: 'max').
      *
-     * This ensures consistency between tooltip values and legend range:
+     * This affects how tooltip values and legend range are calculated:
      * - 'max': Use the maximum value (default, shows peak intensity at each location)
      * - 'sum': Add all values together (good for click counts, cumulative data)
      * - 'mean': Calculate the average value (good for normalized/density data)
      * - 'count': Count the number of points (ignores individual point values)
      *
-     * @example aggregationMode: 'sum' // Accumulate values for click tracking
+     * Note: Visual rendering always uses radial gradients that blend through canvas
+     * compositing. The aggregation mode affects the data reported by tooltips and
+     * legends, not the visual blending of points. For additive visual blending,
+     * use `blendMode: 'lighter'`.
+     *
+     * @example aggregationMode: 'count' // Show number of data points per area
      */
     aggregationMode?: AggregationMode;
 }

--- a/packages/heatmap/src/core/types.ts
+++ b/packages/heatmap/src/core/types.ts
@@ -4,6 +4,17 @@
  * Type definitions for the composable heatmap library.
  */
 
+/**
+ * Aggregation mode for combining multiple points in the same grid cell.
+ * This affects both the tooltip values and legend range.
+ *
+ * - 'sum': Add all values together (default, good for click counts)
+ * - 'max': Use the maximum value (good for peak intensity)
+ * - 'mean': Calculate the average value (good for normalized data)
+ * - 'count': Count the number of points (ignores point values)
+ */
+export type AggregationMode = "sum" | "max" | "mean" | "count";
+
 /** A single data point in the heatmap */
 export interface HeatmapPoint {
     /** X coordinate in pixels */
@@ -219,6 +230,19 @@ export interface HeatmapConfig {
      * @example valueMax: 100 // Always end scale at 100
      */
     valueMax?: number;
+
+    /**
+     * Aggregation mode for combining multiple points in the same grid cell (default: 'max').
+     *
+     * This ensures consistency between tooltip values and legend range:
+     * - 'max': Use the maximum value (default, shows peak intensity at each location)
+     * - 'sum': Add all values together (good for click counts, cumulative data)
+     * - 'mean': Calculate the average value (good for normalized/density data)
+     * - 'count': Count the number of points (ignores individual point values)
+     *
+     * @example aggregationMode: 'sum' // Accumulate values for click tracking
+     */
+    aggregationMode?: AggregationMode;
 }
 
 /**

--- a/packages/heatmap/src/features/legend.spec.ts
+++ b/packages/heatmap/src/features/legend.spec.ts
@@ -343,16 +343,17 @@ describe("withLegend feature", () => {
             expect(getLabels()[4]).toBe("150"); // new gridMax
         });
 
-        it("should show dataMax from points when points overlap", () => {
+        it("should show max value when points overlap (default max mode)", () => {
             heatmap = createHeatmap({ container, gridSize: 10 }, withLegend());
 
-            // Two points in same grid cell - legend shows max of individual point values
+            // Two points in same grid cell - legend shows max value (default aggregation)
+            // This ensures tooltip values and legend values are consistent
             heatmap.setData([
                 { x: 2, y: 2, value: 30 },
                 { x: 4, y: 4, value: 20 }
             ]);
 
-            // Legend shows max point value (30), not aggregated grid value
+            // Legend shows max grid value (30), matching what tooltip would show
             expect(getLabels()[4]).toBe("30");
         });
 

--- a/packages/heatmap/src/index.ts
+++ b/packages/heatmap/src/index.ts
@@ -13,6 +13,7 @@
 
 // Re-export core types
 export type {
+    AggregationMode,
     Heatmap,
     HeatmapConfig,
     HeatmapData,


### PR DESCRIPTION
Control how multiple points in the same grid cell are combined for tooltip and legend value.

| Mode    | Description                     | Use Case                        |
| ------- | ------------------------------- | ------------------------------- |
| `max`   | Use the maximum value (default) | Peak intensity visualization    |
| `sum`   | Add all values together         | Click tracking, cumulative data |
| `mean`  | Calculate the average           | Normalized/density data         |
| `count` | Count the number of points      | Pure density visualization      |